### PR TITLE
Return non-zero exit code when errors occur

### DIFF
--- a/isitup/main.py
+++ b/isitup/main.py
@@ -4,6 +4,8 @@
 from __future__ import absolute_import
 
 import requests
+from click import UsageError
+from click import ClickException
 
 
 def check(url):
@@ -12,18 +14,18 @@ def check(url):
             "https://isitup.org/{0}.json".format(url),
             headers={'User-Agent': 'https://github.com/lord63/isitup'})
     except requests.exceptions.ConnectionError:
-        return ("A network problem(e.g. you're offline; refused connection),"
+        raise UsageError("A network problem(e.g. you're offline; refused connection),"
                 "can't check the site right now.")
     except requests.exceptions.Timeout:
-        return "The request timed out."
+        raise ClickException("The request timed out.")
     except requests.exceptions.RequestException as error:
-        return "Something bad happened:\n{0}".format(error)
+        raise ClickException("Something bad happened:\n{0}".format(error))
     status_code = response.json()["status_code"]
     if status_code == 1:
         return ("Yay, {0} is up.\nIt took {1[response_time]} ms "
                 "for a {1[response_code]} response code with "
                 "an ip of {1[response_ip]}".format(url, response.json()))
     if status_code == 2:
-        return "{0} seems to be down!".format(url)
+        raise ClickException("{0} seems to be down!".format(url))
     if status_code == 3:
-        return "We need a valid domain to check! Try again."
+        raise UsageError("We need a valid domain to check! Try again.")

--- a/test_isitup.py
+++ b/test_isitup.py
@@ -6,6 +6,8 @@ from __future__ import absolute_import
 from isitup.main import check
 
 import pytest
+from click import UsageError
+from click import ClickException
 
 
 def test_website_is_up():
@@ -13,8 +15,12 @@ def test_website_is_up():
 
 
 def test_website_is_down():
-    assert "seems to be down!" in check('justfortestisitup.com')
+    with pytest.raises(ClickException) as exception:
+        check('justfortestisitup.com')
+    assert "seems to be down!" in str(exception.value)
 
 
 def test_invalid_domain():
-    assert check('invalid_domain')[-10:] == "Try again."
+    with pytest.raises(UsageError) as exception:
+        check('invalid_domain')
+    assert "Try again." == str(exception.value)[-10:]


### PR DESCRIPTION
This implements #3 .

One of the tests fails, but it looks like the test fails due to a change in isitup.org's API. It is unrelated to this change and fails on master as well.

I was actually unable to build a working CLI tool and would appreciate the help. From Click's documentation it seems to me that my change will do exactly what I want it to, but I was unable to verify that messages are written to stderr and a non-zero exit code is set.