### PR TITLE
pypandoc.convert deprecated

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ import isitup
 
 try:
     import pypandoc
-    long_description = pypandoc.convert('README.md', 'rst')
+    long_description = pypandoc.convert_file('README.md', 'rst')
 except (IOError, ImportError):
     with open('README.md') as f:
         long_description = f.read()


### PR DESCRIPTION
Fixes a buildtime error while using setuptool 

```
AttributeError: module 'pypandoc' has no attribute 'convert'

ERROR Backend subprocess exited when trying to invoke get_requires_for_build_wheel
```

https://github.com/man-group/pytest-plugins/issues/87#issuecomment-1123830409